### PR TITLE
fog in overworld should be a little more opaque

### DIFF
--- a/InGame/GameObjects/GameObjectTemplates.cs
+++ b/InGame/GameObjects/GameObjectTemplates.cs
@@ -275,7 +275,7 @@ namespace ProjectZ.InGame.GameObjects
 
             ObjectTemplates.Add("animatorL", new GameObjectTemplate(typeof(ObjAnimator), new object[] { 0, null, null, false }));
 
-            ObjectTemplates.Add("fog", new GameObjectTemplate(typeof(ObjFog), new object[] { 1.0f, 0.4f }));
+            ObjectTemplates.Add("fog", new GameObjectTemplate(typeof(ObjFog), new object[] { 1.0f, 0.8f }));
 
             ObjectTemplates.Add("break_real_stuff_start", null);
 


### PR DESCRIPTION
Using the fog in the lost woods for example, the fog is not really that noticeable and making it more opaque would look nicer and add to the atmosphere.