### PR TITLE
Fix animation timing when first get sword

### DIFF
--- a/InGame/GameObjects/ObjLink.cs
+++ b/InGame/GameObjects/ObjLink.cs
@@ -3213,7 +3213,7 @@ namespace ProjectZ.InGame.GameObjects
                     _itemShowCounter = 250;
 
                     if (ShowItem.Name == "sword1")
-                        _itemShowCounter = 5850;
+                        _itemShowCounter = 5650;
                     else if (ShowItem.Name.StartsWith("instrument"))
                         _itemShowCounter = 1000;
                 }


### PR DESCRIPTION
when picking up the sword for the first time, the swing animation after the dialog should be timed with the music, like in the original game.