### PR TITLE
Instrument soft lock fix, face shrine key skip fix, Armos Knight hit type fix

### DIFF
--- a/InGame/GameObjects/MidBoss/MBossArmosKnight.cs
+++ b/InGame/GameObjects/MidBoss/MBossArmosKnight.cs
@@ -309,7 +309,7 @@ namespace ProjectZ.InGame.GameObjects.MidBoss
             if (_hitRepelling)
                 return Values.HitCollision.RepellingParticle;
 
-            if ((damageType & HitType.PegasusBootsSword) != 0)
+            if (((damageType & HitType.SwordSpin) != 0) || ((damageType & HitType.Bow) != 0)) //gatordile - original hit types
             {
                 var hitCollision = _aiDamageState.OnHit(gameObject, direction, damageType, damage, pieceOfPower);
 

--- a/InGame/GameObjects/ObjLink.cs
+++ b/InGame/GameObjects/ObjLink.cs
@@ -1568,7 +1568,7 @@ namespace ProjectZ.InGame.GameObjects
                     Game1.GameManager.PlaySoundEffect("D360-43-2B", false);
                 }
 
-                if (Game1.GbsPlayer.SoundGenerator.WasStopped && Game1.GbsPlayer.SoundGenerator.FinishedPlaying())
+                if (Game1.GbsPlayer.SoundGenerator.WasStopped) // Gatordile - instrument softlock glitch fix
                 {
                     Game1.GameManager.SetMusic(-1, 0);
                     Game1.GameManager.SetMusic(-1, 2);

--- a/InGame/GameObjects/Things/ObjKeyhole.cs
+++ b/InGame/GameObjects/Things/ObjKeyhole.cs
@@ -28,7 +28,7 @@ namespace ProjectZ.InGame.GameObjects.Things
             _itemName = itemName;
             _outputKey = outputKey;
             _strDialog = strDialog;
-
+            if (_strDialog == "keyhole_3") _itemName = "dkey4"; // gatordile - fix face key skip - there may be better approach but the itemName is just getting pulled wrong
             // check if the lock was already activated
             if (_itemName == null || string.IsNullOrEmpty(_outputKey) ||
                 Game1.GameManager.SaveManager.GetString(_outputKey) == "1")

--- a/ProjectZ.csproj
+++ b/ProjectZ.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net6.0-windows</TargetFramework>


### PR DESCRIPTION
Instrument soft lock: Game1.GbsPlayer.SoundGenerator.FinishedPlaying() sometimes just soft locks the game. Removing it seems to have no negative effect at all. It's only used twice in the game. Here for the instrument music and during the intro.

Face Shrine key skip fix: dkey4 is getting wrongly named dkey3 on import. So, dungeon 4 key is required to open dungeon 6. This just fixes the issue on the fly.

Armos Knight: Pegasus boots doesn't kill this boss in the original. A sword spin or arrows is how to kill it.