### PR TITLE
Update BossFinalBoss.cs

### DIFF
--- a/InGame/GameObjects/Bosses/BossFinalBoss.cs
+++ b/InGame/GameObjects/Bosses/BossFinalBoss.cs
@@ -1680,7 +1680,7 @@ namespace ProjectZ.InGame.GameObjects.Bosses
             }
 
             // ganon damage form
-            if (_ganonForm && !_aiDamageState.IsInDamageState() && (damageType & HitType.PegasusBootsSword) != 0)
+            if (_ganonForm && !_aiDamageState.IsInDamageState() && (((damageType & HitType.PegasusBootsSword) != 0) || (damageType & HitType.SwordSpin) != 0)) // gatordile - original hit types
             {
                 _ganonLives -= damage;
                 if (_ganonLives <= 0)


### PR DESCRIPTION
Original shadow Ganon could also be damaged with a spin attack. This adds that feature back in.